### PR TITLE
warning if kyotocabinet unavailable

### DIFF
--- a/descriptastorus/stores/kyotostore.py
+++ b/descriptastorus/stores/kyotostore.py
@@ -37,7 +37,7 @@ try:
         
     KeyValueAPI.register("kyotostore", KyotoStore)
 except:
-    logging.exception("No kyotocabinet available")
+    logging.warning("No kyotocabinet available")
 
 
 


### PR DESCRIPTION
I propose to make kyotostore optional and replace this error by a warning