### PR TITLE
to_np method should return array

### DIFF
--- a/descriptastorus/descriptors/rdDescriptors.py
+++ b/descriptastorus/descriptors/rdDescriptors.py
@@ -43,7 +43,8 @@ import sys
 
 def to_np(vect, nbits):
     arr = numpy.zeros((nbits, ), 'i')
-    return ConvertToNumpyArray(vect, arr)
+    ConvertToNumpyArray(vect, arr)
+    return arr
 
 def clip_sparse(vect, nbits):
     l = [0]*nbits


### PR DESCRIPTION
Dear @bp-kelley ,

Thanks for developing really useful package for chemoinforomatics.
I think to_np function should return array. 
Best,

Taka,
@iwatobipen
