### PR TITLE
Enable install descripastorus w/o pre-install rdkit.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas-flavor==0.2.0
 pandas>=0.24.0
+rdkit-pypi>=2022.3.3

--- a/setup.py
+++ b/setup.py
@@ -30,21 +30,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import sys
-try:
-  import rdkit
-except:
-  print("Descriptastorus requires rkdit to function, this is not installable by pip", file=sys.stderr)
-  print(" see https://rdkit.org for more information", file=sys.stderr)
-  sys.exit(1)
-  
 from setuptools import setup, find_packages
+
 try:
-  from commands import getstatusoutput
+    from commands import getstatusoutput
 except ImportError:
-  from subprocess import getstatusoutput
+    from subprocess import getstatusoutput
 
 import logging
-  
+
 status, output = getstatusoutput("git describe --tags")
 
 if not status:
@@ -53,30 +47,31 @@ if not status:
         if len(data) == 1:
             VERSION = data[0]
         elif data and data[0].lower() == "release":
-            VERSION = "%s.%s"%(data[1], data[2])
+            VERSION = "%s.%s" % (data[1], data[2])
         else:
-            VERSION = "%s.%s"%(data[0], data[1])
+            VERSION = "%s.%s" % (data[0], data[1])
     except:
         raise RunTimeError("git tags must be in the form release-x.y.z or simply x.y.z")
 else:
-  VERSION="2.2.0" # hardcode version
+    VERSION = "2.2.0"  # hardcode version
 
-setup(name='descriptastorus',
-      version=VERSION,
-      description='Descriptor storage and molecular file indexing',
-      author='Brian Kelley',
-      author_email='brian.kelley@novartis.com',
-      url='https://bitbucket.org/novartisnibr/rdkit-descriptastorus/',
-      install_requires=['pandas_flavor'],
-      test_suite='nose.collector',
-      tests_require=['nose', 'pandas_flavor'],
-      include_package_data=True,
-      entry_points={
-          'console_scripts': [
-              'storus = descriptastorus.cli.storus:main',
-              'storus-validate = descriptastorus.cli.validate:main',
-              ]
-          },
-                                                            
-      packages = find_packages())
+setup(
+    name="descriptastorus",
+    version=VERSION,
+    description="Descriptor storage and molecular file indexing",
+    author="Brian Kelley",
+    author_email="brian.kelley@novartis.com",
+    url="https://bitbucket.org/novartisnibr/rdkit-descriptastorus/",
+    install_requires=["pandas_flavor", "rdkit"],
+    test_suite="nose.collector",
+    tests_require=["nose", "pandas_flavor"],
+    include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "storus = descriptastorus.cli.storus:main",
+            "storus-validate = descriptastorus.cli.validate:main",
+        ]
+    },
+    packages=find_packages(),
+)
 


### PR DESCRIPTION
remove import for rdkit, add rdkit to requirements, add rdkit to install_requires.

This reflects changes in rdkit allowing it to be installed via pip (and all downstream tooling like pipenv, poetry, etc.): https://github.com/rdkit/rdkit/pull/5373

Closes #17 

## Testing

- rdkit is not installed
```console
(eis)  ✘  ~/P/p/descriptastorus   master ±  python
Python 3.10.0 (default, Mar  3 2022, 03:57:21) [Clang 12.0.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import rdkit
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'rdkit'
>>>
```

- install descriptastorus
```console
(eis)  ~/P/p/descriptastorus   master ±  pip install .
Processing /Users/raymondgasper/Projects/personal/descriptastorus
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
Collecting pandas_flavor
  Downloading pandas_flavor-0.3.0-py3-none-any.whl (6.3 kB)
Collecting rdkit
  Downloading rdkit-2022.3.3-cp310-cp310-macosx_10_9_x86_64.whl (17.9 MB)
     |████████████████████████████████| 17.9 MB 26.8 MB/s
Requirement already satisfied: pandas>=0.23 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from pandas_flavor->descriptastorus==2.3.0.6) (1.4.1)
Collecting lazy-loader==0.1rc2
  Downloading lazy_loader-0.1rc2-py3-none-any.whl (5.1 kB)
Collecting xarray
  Downloading xarray-2022.3.0-py3-none-any.whl (870 kB)
     |████████████████████████████████| 870 kB 13.4 MB/s
Requirement already satisfied: python-dateutil>=2.8.1 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from pandas>=0.23->pandas_flavor->descriptastorus==2.3.0.6) (2.8.2)
Requirement already satisfied: numpy>=1.21.0 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from pandas>=0.23->pandas_flavor->descriptastorus==2.3.0.6) (1.22.3)
Requirement already satisfied: pytz>=2020.1 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from pandas>=0.23->pandas_flavor->descriptastorus==2.3.0.6) (2021.3)
Requirement already satisfied: six>=1.5 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from python-dateutil>=2.8.1->pandas>=0.23->pandas_flavor->descriptastorus==2.3.0.6) (1.16.0)
Requirement already satisfied: Pillow in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from rdkit->descriptastorus==2.3.0.6) (9.0.1)
Requirement already satisfied: packaging>=20.0 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from xarray->pandas_flavor->descriptastorus==2.3.0.6) (21.3)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages (from packaging>=20.0->xarray->pandas_flavor->descriptastorus==2.3.0.6) (3.0.7)
Building wheels for collected packages: descriptastorus
  Building wheel for descriptastorus (setup.py) ... done
  Created wheel for descriptastorus: filename=descriptastorus-2.3.0.6-py3-none-any.whl size=60706 sha256=c2f20d71a0f412c2022723c21b613d687a3ed7bfae43df9e7c14b22fdde90c3d
  Stored in directory: /private/var/folders/1m/281yfqmj42n90_znys0027y00000gp/T/pip-ephem-wheel-cache-7lzqoiy9/wheels/12/b1/15/40ac169c11f221b9c1f4bbfcd683fe6f7732156eda33346650
Successfully built descriptastorus
Installing collected packages: xarray, lazy-loader, rdkit, pandas-flavor, descriptastorus
Successfully installed descriptastorus-2.3.0.6 lazy-loader-0.1rc2 pandas-flavor-0.3.0 rdkit-2022.3.3 xarray-2022.3.0
```

- now we can import
```console
(eis)  ~/P/p/descriptastorus   master ±  python
Python 3.10.0 (default, Mar  3 2022, 03:57:21) [Clang 12.0.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import rdkit
>>> import descriptastorus
WARNING:root:No normalization for BCUT2D_MWHI
WARNING:root:No normalization for BCUT2D_MWLOW
WARNING:root:No normalization for BCUT2D_CHGHI
WARNING:root:No normalization for BCUT2D_CHGLO
WARNING:root:No normalization for BCUT2D_LOGPHI
WARNING:root:No normalization for BCUT2D_LOGPLOW
WARNING:root:No normalization for BCUT2D_MRHI
WARNING:root:No normalization for BCUT2D_MRLOW
```

- run tests
```console
(eis)  ~/P/p/descriptastorus   master  pytest tests
===================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.10.0, pytest-7.1.0, pluggy-1.0.0
rootdir: /Users/raymondgasper/Projects/personal/descriptastorus
plugins: anyio-3.5.0
collected 7 items

tests/test_keyvalue.py ..                                                                                                                                                                                                                               [ 28%]
tests/test_pandas.py .                                                                                                                                                                                                                                  [ 42%]
tests/test_rawStore.py .                                                                                                                                                                                                                                [ 57%]
tests/test_smiles_reindex.py ..                                                                                                                                                                                                                         [ 85%]
tests/test_test1.py .                                                                                                                                                                                                                                   [100%]

====================================================================================================================== warnings summary =======================================================================================================================
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
  /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages/descriptastorus/descriptors/DescriptorGenerator.py:100: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    return [ (self.NAME + "_calculated", numpy.bool) ] + self.columns

tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
tests/test_pandas.py::TestPandasDataFrame::test_pd_descriptors
  /usr/local/anaconda3/envs/eis/lib/python3.10/site-packages/rdkit/Chem/Graphs.py:43: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    res = numpy.zeros(nAtoms + 1, numpy.float)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================== 7 passed, 13 warnings in 7.33s ================================================================================================================
```