### PR TITLE
Update to rdkit 2024+

### DIFF
--- a/descriptastorus/__init__.py
+++ b/descriptastorus/__init__.py
@@ -34,4 +34,4 @@ from .mode import Mode
 
 # try and load key stores
 from . import stores
-__version__ = "2.5.0.19"
+__version__ = "2.5.0.25"

--- a/descriptastorus/__init__.py
+++ b/descriptastorus/__init__.py
@@ -34,4 +34,4 @@ from .mode import Mode
 
 # try and load key stores
 from . import stores
-__version__ = "2.5.0.25"
+__version__ = "2.7.0"

--- a/descriptastorus/descriptors/rdNormalizedDescriptors.py
+++ b/descriptastorus/descriptors/rdNormalizedDescriptors.py
@@ -45,6 +45,13 @@ for name, (dist, params, minV,maxV,avg,std) in dists.dists.items():
     arg = params[:-2]
     loc = params[-2]
     scale = params[-1]
+    
+    if dist in ['gilbrat', 'gibrat']:
+        # fix change in scikit learn
+        if hasattr(st, 'gilbrat'):
+            dist = 'gilbrat'
+        else:
+            dist = 'gibrat'
 
     if dist in ['gilbrat', 'gibrat']:
         # fix change in scikit learn
@@ -67,11 +74,11 @@ for name, (dist, params, minV,maxV,avg,std) in dists.dists.items():
 #    if name not in cdfs:
 #        logger.warning("No normalization for %s", name)
 
-def applyNormalizedFunc(name, m):
+def applyNormalizedFunc(funcs, name, m):
     if name not in cdfs:
         return 0.0
     try:
-        return cdfs[name](rdDescriptors.applyFunc(name,m))
+        return cdfs[name](rdDescriptors.applyFunc(funcs, name,m))
     except:
         logger.exception("Could not compute %s for molecule", name)
         return 0.0
@@ -84,7 +91,7 @@ class RDKit2DNormalized(rdDescriptors.RDKit2D):
     NAME = "RDKit2DNormalized"
 
     def calculateMol(self, m, smiles, internalParsing=False):
-        res = [ applyNormalizedFunc(name, m) for name, _ in self.columns ]
+        res = [ applyNormalizedFunc(self.funcs, name, m) for name, _ in self.columns ]
         return res   
     
 RDKit2DNormalized()
@@ -100,11 +107,11 @@ for name, bins in hists.hists.items():
     
     histcdfs[name] = histcdf
 
-def applyHistogramNormalizedFunc(name, m):
+def applyHistogramNormalizedFunc(funcs, name, m):
     if name not in cdfs:
         return 0.0
     try:
-        return histcdfs[name](rdDescriptors.applyFunc(name,m))
+        return histcdfs[name](rdDescriptors.applyFunc(self,funcs, name,m))
     except:
         logging.exception("Could not compute %s for molecule", name)
         return 0.0
@@ -120,7 +127,7 @@ class RDKit2DHistogramNormalized(rdDescriptors.RDKit2D):
     NAME = "RDKit2DHistogramNormalized"
 
     def calculateMol(self, m, smiles, internalParsing=False):
-        res = [ applyHistogramNormalizedFunc(name, m) for name, _ in self.columns ]
+        res = [ applyHistogramNormalizedFunc(self.funcs, name, m) for name, _ in self.columns ]
         return res   
     
 RDKit2DHistogramNormalized()

--- a/descriptastorus/make_store.py
+++ b/descriptastorus/make_store.py
@@ -40,7 +40,6 @@ import logging
 from descriptastorus import MolFileIndex, raw
 from .keyvalue import KeyValueAPI
 from .DescriptaStore import get_options
-import tqdm
 
 logger = logging.getLogger("descriptastorus")
 
@@ -55,7 +54,9 @@ logger = logging.getLogger("descriptastorus")
 # args.nameColumn
 # args.seperator
 
-DEFAULT_KEYSTORE = "kyotostore"
+# we used to use kyotocabinet which is not longer maintained or available
+#  use the dumb store as the default for now but probably move to leveldb
+DEFAULT_KEYSTORE = "dbmstore"
 class MakeStorageOptions:
     def __init__(self, storage, smilesfile, 
                  hasHeader, smilesColumn, nameColumn, seperator,

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if not status:
 
 else:
     logging.error("Could not run git to get version information... using hard coded version which is likely incorrect")
-    VERSION = "2.5.1"  # hardcode version
+    VERSION = "2.7.0"  # hardcode version
 
 setup(
     name='descriptastorus',


### PR DESCRIPTION
* Use the modern fingerprint generator.
* Use the old smarts pattern for fr_unbrch_alkane so results don't change.

The newer rdkit descriptors will be available in v3.0.0