### PR TITLE
Fix version

### DIFF
--- a/descriptastorus/__init__.py
+++ b/descriptastorus/__init__.py
@@ -34,4 +34,4 @@ from .mode import Mode
 
 # try and load key stores
 from . import stores
-__version__ = "2.7.0.1"
+__version__ = "2.7.0.5"

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if not status:
 
 else:
     logging.error("Could not run git to get version information... using hard coded version which is likely incorrect")
-    VERSION = "2.7.0"  # hardcode version
+    VERSION = "2.7.0.5"  # hardcode version
 
 setup(
     name='descriptastorus',


### PR DESCRIPTION
Fixed an inconsistency between the metadata and actual version published to PyPI
```
Metadata for descriptastorus==2.7.0.4 was inconsistent:
        Package metadata version `2.7.0` does not match given version `2.7.0.4`
```